### PR TITLE
Fix metadata reading code for forked package name

### DIFF
--- a/src/drf_yasg/__init__.py
+++ b/src/drf_yasg/__init__.py
@@ -3,13 +3,15 @@
 __author__ = """Cristi V."""
 __email__ = 'cristi@cvjd.me'
 
+HS_PREFIX = 'humansignal_'
+
 try:
     from importlib.metadata import version
-    __version__ = version(__name__)
+    __version__ = version(HS_PREFIX + __name__)
 except ImportError:  # Python < 3.8
     try:
         from pkg_resources import DistributionNotFound, get_distribution
-        __version__ = get_distribution(__name__).version
+        __version__ = get_distribution(HS_PREFIX + __name__).version
     except DistributionNotFound:  # pragma: no cover
         # package is not installed
         pass


### PR DESCRIPTION
```
Python 3.12.7 (main, Nov  8 2024, 00:49:33) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from importlib.metadata import version
>>> version('drf_yasg')
Traceback (most recent call last):
  File "/home/jo/.pyenv/versions/3.12.7/lib/python3.12/importlib/metadata/__init__.py", line 397, in from_name
    return next(cls.discover(name=name))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
StopIteration

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jo/.pyenv/versions/3.12.7/lib/python3.12/importlib/metadata/__init__.py", line 889, in version
    return distribution(distribution_name).version
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jo/.pyenv/versions/3.12.7/lib/python3.12/importlib/metadata/__init__.py", line 862, in distribution
    return Distribution.from_name(distribution_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jo/.pyenv/versions/3.12.7/lib/python3.12/importlib/metadata/__init__.py", line 399, in from_name
    raise PackageNotFoundError(name)
importlib.metadata.PackageNotFoundError: No package metadata was found for drf_yasg
>>> version('humansignal_drf_yasg')
'1.21.10'
```